### PR TITLE
데이터베이스에 저장된 서울, 경기도 동물병원 지역 필터 기능 

### DIFF
--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -68,9 +68,6 @@ public class WebSecurityConfig {
                     .requestMatchers(GET, "/community/articles/**");
         };
 
-
-
-
     }
 
     @Bean

--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -34,7 +34,7 @@ public class WebSecurityConfig {
 
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authHttp ->
-                        authHttp.requestMatchers("/register", "/login/**").permitAll()
+                        authHttp.requestMatchers("/register", "/login/**", "/hospitals/**").permitAll()
                                 .requestMatchers(POST, "/community").authenticated())
                 .oauth2Login(oauth2Login -> oauth2Login
                         .loginPage("/login")
@@ -60,7 +60,7 @@ public class WebSecurityConfig {
         return web -> {
             web.ignoring()
                     // 해당 경로는 security filter chain을 생략
-                    .requestMatchers("/register", "/login/**");
+                    .requestMatchers("/register", "/login/**", "/hospitals/**");
         };
     }
 

--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -68,6 +68,7 @@ public class WebSecurityConfig {
                     .requestMatchers(GET, "/community/articles/**");
         };
 
+
     }
 
     @Bean

--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -68,6 +68,9 @@ public class WebSecurityConfig {
                     .requestMatchers(GET, "/community/articles/**");
         };
 
+
+
+
     }
 
     @Bean

--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -35,7 +35,7 @@ public class WebSecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authHttp ->
                         authHttp.requestMatchers("/register", "/login/**", "/community/search/**").permitAll()
-                                .requestMatchers(GET, "/community/articles/**", "/hospitals/**").permitAll()
+                                .requestMatchers(GET, "/community/articles/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2Login -> oauth2Login
@@ -61,11 +61,13 @@ public class WebSecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> {
             web.ignoring()
+                    // 해당 경로는 security filter chain을 생략
                     // 즉 permitAll로 설정하여 로그인 없이 접근 가능한 URL을 아래에 추가하여
                     // 해당 URL 요청들은 JwtFilter, JwtExceptionFilter를 포함한 스프링 시큐리티의 필터 체인을 생략
                     .requestMatchers("/register", "/login/**", "/community/search/**")
-                    .requestMatchers(GET, "/community/articles/**", "/hospitals/**");
+                    .requestMatchers(GET, "/community/articles/**");
         };
+
     }
 
     @Bean

--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -67,8 +67,6 @@ public class WebSecurityConfig {
                     .requestMatchers("/register", "/login/**", "/community/search/**")
                     .requestMatchers(GET, "/community/articles/**");
         };
-
-
     }
 
     @Bean

--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -34,8 +34,10 @@ public class WebSecurityConfig {
 
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authHttp ->
-                        authHttp.requestMatchers("/register", "/login/**", "/hospitals/**").permitAll()
-                                .requestMatchers(POST, "/community").authenticated())
+                        authHttp.requestMatchers("/register", "/login/**", "/community/search/**").permitAll()
+                                .requestMatchers(GET, "/community/articles/**", "/hospitals/**").permitAll()
+                                .anyRequest().authenticated()
+                )
                 .oauth2Login(oauth2Login -> oauth2Login
                         .loginPage("/login")
                         .successHandler(oAuth2SuccessHandler)
@@ -59,8 +61,10 @@ public class WebSecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> {
             web.ignoring()
-                    // 해당 경로는 security filter chain을 생략
-                    .requestMatchers("/register", "/login/**", "/hospitals/**");
+                    // 즉 permitAll로 설정하여 로그인 없이 접근 가능한 URL을 아래에 추가하여
+                    // 해당 URL 요청들은 JwtFilter, JwtExceptionFilter를 포함한 스프링 시큐리티의 필터 체인을 생략
+                    .requestMatchers("/register", "/login/**", "/community/search/**")
+                    .requestMatchers(GET, "/community/articles/**", "/hospitals/**");
         };
     }
 

--- a/src/main/java/com/example/mypetlife/controller/HospitalController.java
+++ b/src/main/java/com/example/mypetlife/controller/HospitalController.java
@@ -1,0 +1,51 @@
+package com.example.mypetlife.controller;
+
+import com.example.mypetlife.dto.hospital.DistrictResponseDto;
+import com.example.mypetlife.dto.hospital.gyeonggiDo.GyeonggiHospitalCountryResponseDto;
+import com.example.mypetlife.dto.hospital.gyeonggiDo.GyeonggiHospitalInfoResponseDto;
+import com.example.mypetlife.dto.hospital.seoul.SeoulHospitalInfoResponseDto;
+import com.example.mypetlife.service.HospitalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hospitals")
+public class HospitalController {
+    private final HospitalService hospitalService;
+
+    // 병원 조회 메인 페이지 (지도)
+
+    // 시 도 필터
+    @GetMapping("/{city}")
+    public List<DistrictResponseDto> hospitalCityFilter(@PathVariable final String city) {
+        return hospitalService.getHospitalCity(city);
+    }
+
+    // 서울 ~구 동물병원 객체 반환
+    @GetMapping("/seoul/{city}/{district}")
+    public List<SeoulHospitalInfoResponseDto> seoulHospitalDistrictFilter(@PathVariable final String city,
+                                                                          @PathVariable final String district) {
+        return hospitalService.getSeoulHospital(city, district);
+    }
+
+    // 경기도 ~시 동물병원 객체 반환 ~구 필터
+    @GetMapping("/gyeonggi/{city}/{country}")
+    public List<GyeonggiHospitalCountryResponseDto> gyeonggiDoHospitalCountryFilter(@PathVariable final String city,
+                                                                                    @PathVariable final String country) {
+        return hospitalService.getGyeonggiDoHospitalDistrict(city, country);
+    }
+
+    // 경기도 ~시 ~구 동물병원 객체 반환
+    @GetMapping("/gyeonggi/{city}/{country}/{district}")
+    public List<GyeonggiHospitalInfoResponseDto> gyeonggiHospitalStreetFilter(@PathVariable final String city,
+                                                                              @PathVariable final String country,
+                                                                              @PathVariable final String district) {
+        return hospitalService.getGyeonggiDoHospital(city, country, district);
+    }
+}

--- a/src/main/java/com/example/mypetlife/dto/hospital/DistrictResponseDto.java
+++ b/src/main/java/com/example/mypetlife/dto/hospital/DistrictResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.mypetlife.dto.hospital;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class DistrictResponseDto {
+    private List<String> district;
+
+    public DistrictResponseDto(final List<String> district) {
+        this.district = district;
+    }
+}

--- a/src/main/java/com/example/mypetlife/dto/hospital/gyeonggiDo/GyeonggiHospitalCountryResponseDto.java
+++ b/src/main/java/com/example/mypetlife/dto/hospital/gyeonggiDo/GyeonggiHospitalCountryResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.mypetlife.dto.hospital.gyeonggiDo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class GyeonggiHospitalCountryResponseDto {
+
+    private List<GyeonggiHospitalInfoResponseDto> gyeonggiHospitalInfo;
+    private List<String> streetList;
+
+    public GyeonggiHospitalCountryResponseDto(final List<GyeonggiHospitalInfoResponseDto> gyeonggiHospitalInfo,
+                                              final List<String> streetList) {
+        this.gyeonggiHospitalInfo = gyeonggiHospitalInfo;
+        this.streetList = streetList;
+    }
+}

--- a/src/main/java/com/example/mypetlife/dto/hospital/gyeonggiDo/GyeonggiHospitalInfoResponseDto.java
+++ b/src/main/java/com/example/mypetlife/dto/hospital/gyeonggiDo/GyeonggiHospitalInfoResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.mypetlife.dto.hospital.gyeonggiDo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GyeonggiHospitalInfoResponseDto {
+
+    private String city;
+    private String country;
+    private String district;
+    private String street;
+    private String hospitalStreetNumber;
+    private String hospitalName;
+    private Integer reviewCount;
+
+
+    public GyeonggiHospitalInfoResponseDto(final String city, final String country, final String district,
+                                           final String street, final String hospitalStreetNumber,
+                                           final Integer reviewCount, final String hospitalName) {
+        this.city = city;
+        this.country = country;
+        this.district = district;
+        this.street = street;
+        this.hospitalStreetNumber = hospitalStreetNumber;
+        this.hospitalName = hospitalName;
+        this.reviewCount = reviewCount;
+    }
+}

--- a/src/main/java/com/example/mypetlife/dto/hospital/seoul/SeoulHospitalInfoResponseDto.java
+++ b/src/main/java/com/example/mypetlife/dto/hospital/seoul/SeoulHospitalInfoResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.mypetlife.dto.hospital.seoul;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SeoulHospitalInfoResponseDto {
+    private String city;
+    private String district;
+    private String street;
+    private String hospitalStreetNumber;
+    private String hospitalName;
+    private Integer reviewCount;
+
+
+    public SeoulHospitalInfoResponseDto(final String city, final String district,
+                                        final String street, final String hospitalStreetNumber,
+                                        final Integer reviewCount, final String hospitalName) {
+        this.city = city;
+        this.district = district;
+        this.street = street;
+        this.hospitalStreetNumber = hospitalStreetNumber;
+        this.hospitalName = hospitalName;
+        this.reviewCount = reviewCount;
+    }
+}

--- a/src/main/java/com/example/mypetlife/entity/hospital/address/GyeonggiDoAddress.java
+++ b/src/main/java/com/example/mypetlife/entity/hospital/address/GyeonggiDoAddress.java
@@ -1,8 +1,10 @@
 package com.example.mypetlife.entity.hospital.address;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class GyeonggiDoAddress {
     // 도
     private String city;

--- a/src/main/java/com/example/mypetlife/entity/hospital/address/SeoulAddress.java
+++ b/src/main/java/com/example/mypetlife/entity/hospital/address/SeoulAddress.java
@@ -1,8 +1,10 @@
 package com.example.mypetlife.entity.hospital.address;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class SeoulAddress {
     // 시
     private String city;

--- a/src/main/java/com/example/mypetlife/init/parseApi/ParseJsonGyeonggiDo.java
+++ b/src/main/java/com/example/mypetlife/init/parseApi/ParseJsonGyeonggiDo.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class ParseJsonGyeonggiDo {
     private final GyeonggiDoHospitalRepository gyeonggiDoHospitalRepository;
 
-    @PostConstruct
+//    @PostConstruct
     public String storeGyeonggiPetHospital() throws IOException, ParseException {
         List<GyeonggiDoHospital> addressList = new ArrayList<>();
         //2311

--- a/src/main/java/com/example/mypetlife/init/parseApi/ParseJsonSeoul.java
+++ b/src/main/java/com/example/mypetlife/init/parseApi/ParseJsonSeoul.java
@@ -23,7 +23,7 @@ public class ParseJsonSeoul {
 
     // DB 저장
     // 인텔리제이 시작할때 제일 먼저 실행
-    @PostConstruct
+//    @PostConstruct
     public String storeSeoulPetHospital() throws IOException, ParseException {
         List<SeoulHospital> addressList = new ArrayList<>();
         // 2079

--- a/src/main/java/com/example/mypetlife/repository/hospital/GyeonggiDoHospitalRepository.java
+++ b/src/main/java/com/example/mypetlife/repository/hospital/GyeonggiDoHospitalRepository.java
@@ -2,6 +2,27 @@ package com.example.mypetlife.repository.hospital;
 
 import com.example.mypetlife.entity.hospital.GyeonggiDoHospital;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface GyeonggiDoHospitalRepository extends JpaRepository<GyeonggiDoHospital, Long> {
+
+    @Query("SELECT gyeonggi FROM GyeonggiDoHospital gyeonggi WHERE gyeonggi.gyeonggiDoAddress.city = :city")
+    List<GyeonggiDoHospital> findByGyeonggiDoAddress_City(@Param("city") final String city);
+
+
+    @Query("SELECT gyeonggi FROM GyeonggiDoHospital gyeonggi WHERE gyeonggi.gyeonggiDoAddress.city = :city " +
+            "AND gyeonggi.gyeonggiDoAddress.country = :country")
+    List<GyeonggiDoHospital> findByGyeonggiDoAddress_CityAndGyeonggiDoAddress_Country(@Param("city") final String city,
+                                                                                      @Param("country") final String country);
+
+    @Query("SELECT gyeonggi FROM GyeonggiDoHospital gyeonggi WHERE gyeonggi.gyeonggiDoAddress.city = :city " +
+            "AND gyeonggi.gyeonggiDoAddress.country = :country " +
+            "AND gyeonggi.gyeonggiDoAddress.district = :district")
+    List<GyeonggiDoHospital> findByGyeonggiDoAddress_CityAndGyeonggiDoAddress_CountryAndAndGyeonggiDoAddress_District
+            (@Param("city") final String city,
+             @Param("country") final String country,
+             @Param("district") final String district);
 }

--- a/src/main/java/com/example/mypetlife/repository/hospital/SeoulHospitalRepository.java
+++ b/src/main/java/com/example/mypetlife/repository/hospital/SeoulHospitalRepository.java
@@ -2,6 +2,20 @@ package com.example.mypetlife.repository.hospital;
 
 import com.example.mypetlife.entity.hospital.SeoulHospital;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SeoulHospitalRepository extends JpaRepository<SeoulHospital, Long> {
+    // ~구 필터 쿼리
+    @Query("SELECT seoul FROM SeoulHospital seoul WHERE seoul.seoulAddress.city = :city")
+    List<SeoulHospital> findBySeoulAddress_City(@Param("city") final String city);
+
+    // 사용자가 선택한 서울시 ~구 동물병원 객체 조회 쿼리
+    @Query("SELECT seoul FROM SeoulHospital seoul WHERE seoul.seoulAddress.city = :city " +
+            "AND seoul.seoulAddress.district = :district")
+    List<SeoulHospital> findBySeoulAddress_CityAndSeoulAddress_District(@Param("city") final String city,
+                                                                        @Param("district") final String district);
 }
+

--- a/src/main/java/com/example/mypetlife/service/HospitalService.java
+++ b/src/main/java/com/example/mypetlife/service/HospitalService.java
@@ -1,0 +1,132 @@
+package com.example.mypetlife.service;
+
+import com.example.mypetlife.dto.hospital.DistrictResponseDto;
+import com.example.mypetlife.dto.hospital.gyeonggiDo.GyeonggiHospitalCountryResponseDto;
+import com.example.mypetlife.dto.hospital.gyeonggiDo.GyeonggiHospitalInfoResponseDto;
+import com.example.mypetlife.dto.hospital.seoul.SeoulHospitalInfoResponseDto;
+import com.example.mypetlife.entity.hospital.GyeonggiDoHospital;
+import com.example.mypetlife.entity.hospital.SeoulHospital;
+import com.example.mypetlife.repository.hospital.GyeonggiDoHospitalRepository;
+import com.example.mypetlife.repository.hospital.SeoulHospitalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HospitalService {
+    private final GyeonggiDoHospitalRepository gyeonggiDoHospitalRepository;
+    private final SeoulHospitalRepository seoulHospitalRepository;
+
+
+    // 1차 필터 서울 / 경기도
+    public List<DistrictResponseDto> getHospitalCity(final String city) {
+        Set<String> set = new HashSet<>();
+        if (city.equals("서울특별시")) {
+            List<SeoulHospital> seoulHospitalsCityList = seoulHospitalRepository.findBySeoulAddress_City(city);
+
+            for (int i = 1; i < seoulHospitalsCityList.size(); i++) {
+                String district = seoulHospitalsCityList.get(i).getSeoulAddress().getDistrict();
+                set.add(district);
+            }
+
+        } else if (city.equals("경기도")) {
+            List<GyeonggiDoHospital> gyeonggiDoHospitalsCountryList
+                    = gyeonggiDoHospitalRepository.findByGyeonggiDoAddress_City(city);
+
+            for (int i = 1; i < gyeonggiDoHospitalsCountryList.size(); i++) {
+                String country = gyeonggiDoHospitalsCountryList.get(i).getGyeonggiDoAddress().getCountry();
+                set.add(country);
+            }
+        }
+
+
+        List<String> cityList = new ArrayList<>(set);
+        DistrictResponseDto districtResponseDto = new DistrictResponseDto(cityList);
+
+        return List.of(districtResponseDto);
+    }
+
+    // 2차 필터 서울시 ~구
+    public List<SeoulHospitalInfoResponseDto> getSeoulHospital(final String city, final String district) {
+        List<SeoulHospital> seoulHospitalsList
+                = seoulHospitalRepository.findBySeoulAddress_CityAndSeoulAddress_District(city, district);
+
+        List<SeoulHospitalInfoResponseDto> seoulHospitalInfoResponseDto = new ArrayList<>();
+        for (int i = 1; i < seoulHospitalsList.size(); i++) {
+            String findCity = seoulHospitalsList.get(i).getSeoulAddress().getCity();
+            String findDistrict = seoulHospitalsList.get(i).getSeoulAddress().getDistrict();
+            String findStreet = seoulHospitalsList.get(i).getSeoulAddress().getStreet();
+            String findHospitalStreetNumber = seoulHospitalsList.get(i).getSeoulAddress().getHospitalStreetNumber();
+            int reviewCount = seoulHospitalsList.get(i).getReviews().size();
+            String findHospitalName = seoulHospitalsList.get(i).getHospitalName();
+
+            seoulHospitalInfoResponseDto.add(new SeoulHospitalInfoResponseDto(findCity, findDistrict, findStreet,
+                    findHospitalStreetNumber, reviewCount, findHospitalName));
+        }
+
+        return seoulHospitalInfoResponseDto;
+    }
+
+
+    // 2차 필터 경기도 xx시의 동물병원 리스트 ~구 필터
+    public List<GyeonggiHospitalCountryResponseDto> getGyeonggiDoHospitalDistrict(final String city, final String country) {
+        List<GyeonggiDoHospital> gyeonggiDoHospitalsCountryList
+                = gyeonggiDoHospitalRepository.findByGyeonggiDoAddress_CityAndGyeonggiDoAddress_Country(city, country);
+        Set<String> set = new HashSet<>();
+        List<GyeonggiHospitalInfoResponseDto> gyeonggiHospitalInfoResponseDto = new ArrayList<>();
+
+
+        for (int i = 1; i < gyeonggiDoHospitalsCountryList.size(); i++) {
+            String findCity = gyeonggiDoHospitalsCountryList.get(i).getGyeonggiDoAddress().getCity();
+            String findCountry = gyeonggiDoHospitalsCountryList.get(i).getGyeonggiDoAddress().getCountry();
+            String findDistrict = gyeonggiDoHospitalsCountryList.get(i).getGyeonggiDoAddress().getDistrict();
+            String findStreet = gyeonggiDoHospitalsCountryList.get(i).getGyeonggiDoAddress().getStreet();
+            String findHospitalStreetNumber = gyeonggiDoHospitalsCountryList.get(i).getGyeonggiDoAddress().getHospitalStreetNumber();
+            int reviewCount = gyeonggiDoHospitalsCountryList.get(i).getReviews().size();
+            String findHospitalName = gyeonggiDoHospitalsCountryList.get(i).getHospitalName();
+
+            gyeonggiHospitalInfoResponseDto.add(new GyeonggiHospitalInfoResponseDto(findCity, findCountry, findDistrict, findStreet,
+                    findHospitalStreetNumber, reviewCount, findHospitalName));
+
+            set.add(findDistrict);
+        }
+
+        List<String> list = new ArrayList<>(set);
+        GyeonggiHospitalCountryResponseDto gyeonggiHospitalCountryResponseDto = new GyeonggiHospitalCountryResponseDto(gyeonggiHospitalInfoResponseDto, list);
+        return List.of(gyeonggiHospitalCountryResponseDto);
+    }
+
+
+    // 3차 필터 경기도 xx시 xx구의 동물병원 리스트
+    public List<GyeonggiHospitalInfoResponseDto> getGyeonggiDoHospital(final String city, final String country,
+                                                                       final String district) {
+        List<GyeonggiDoHospital> gyeonggiDoHospitalsList
+                = gyeonggiDoHospitalRepository.
+                findByGyeonggiDoAddress_CityAndGyeonggiDoAddress_CountryAndAndGyeonggiDoAddress_District(city, country, district);
+
+        List<GyeonggiHospitalInfoResponseDto> gyeonggiHospitalInfoResponseDto = new ArrayList<>();
+
+        for (int i = 1; i < gyeonggiDoHospitalsList.size(); i++) {
+            String findCity = gyeonggiDoHospitalsList.get(i).getGyeonggiDoAddress().getCity();
+            String findCountry = gyeonggiDoHospitalsList.get(i).getGyeonggiDoAddress().getCountry();
+            String findDistrict = gyeonggiDoHospitalsList.get(i).getGyeonggiDoAddress().getDistrict();
+            String findStreet = gyeonggiDoHospitalsList.get(i).getGyeonggiDoAddress().getStreet();
+            String findHospitalStreetNumber = gyeonggiDoHospitalsList.get(i).getGyeonggiDoAddress().getHospitalStreetNumber();
+            int reviewCount = gyeonggiDoHospitalsList.get(i).getReviews().size();
+            String findHospitalName = gyeonggiDoHospitalsList.get(i).getHospitalName();
+
+
+            gyeonggiHospitalInfoResponseDto.add(new GyeonggiHospitalInfoResponseDto(findCity, findCountry, findDistrict, findStreet,
+                    findHospitalStreetNumber, reviewCount, findHospitalName));
+        }
+
+        return gyeonggiHospitalInfoResponseDto;
+    }
+}


### PR DESCRIPTION
close #23 
- 데이터베이스에 데이터가 잘 저장되었으면, init 폴더의 parseApi 폴더에서 PostConstruct 어노테이션을 주석 처리 해줘야합니다.
- WebSecurityConfig 클래스의 url 설정에서 /hospital/** 경로를 추가했습니다.
`http://localhost:8080/hospitals/경기도 혹은 서울특별시` 의 URL 요청을 보낼경우 시 군 구 필터링되어 보여지게 됩니다.
`http://localhost:8080/hospitals/seoul/서울특별시/xx구` 의 URL 요청을 보낼경우 xx구의 동물병원 전체가 보여지게 됩니다.
`http://localhost:8080/hospitals/gyeonggi/경기도/xx시` 의 URL 요청을 보낼경우 xx시의 동물병원 전체가 보여지게 됩니다.
`http://localhost:8080/hospitals/gyeonggi/경기도/xx시/xx구` 의 URL 요청을 보낼경우 xx구의 동물병원 전체가 보여지게 됩니다.
