### PR TITLE
jwt access token, refresh token 구분하여 발급

### DIFF
--- a/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSecurityConfig.java
@@ -32,7 +32,7 @@ public class WebSecurityConfig {
 
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authHttp ->
-                        authHttp.requestMatchers("/register", "/login/**", "/community/search/**", "/hospitals/**").permitAll()
+                        authHttp.requestMatchers("/register", "/login/**", "/community/search/**", "/hospitals/**", "/access_token").permitAll()
                                 .requestMatchers(GET, "/community/articles/**").permitAll()
                                 .anyRequest().authenticated()
                 )
@@ -62,7 +62,7 @@ public class WebSecurityConfig {
                     // 해당 경로는 security filter chain을 생략
                     // 즉 permitAll로 설정하여 로그인 없이 접근 가능한 URL을 아래에 추가하여
                     // 해당 URL 요청들은 JwtFilter, JwtExceptionFilter를 포함한 스프링 시큐리티의 필터 체인을 생략
-                    .requestMatchers("/register", "/login/**", "/community/search/**", "/hospitals/**")
+                    .requestMatchers("/register", "/login/**", "/community/search/**", "/hospitals/**", "/access_token")
                     .requestMatchers(GET, "/community/articles/**");
         };
 

--- a/src/main/java/com/example/mypetlife/controller/UserController.java
+++ b/src/main/java/com/example/mypetlife/controller/UserController.java
@@ -58,7 +58,18 @@ public class UserController {
     }
 
     /**
-     *
+     * [GET] /login/kakao
+     * 카카오 회원 로그인: JWT 토큰 발급
+     */
+    @GetMapping("/login/kakao")
+    public JwtTokenDto login(@RequestParam(name = "access_token") String accessToken,
+                             @RequestParam(name = "refresh_token") String refreshToken) {
+
+        return new JwtTokenDto(accessToken, refreshToken);
+    }
+
+    /**
+     * [POST] /access_token
      * Refresh Token 검증 후 유효하면 새로운 Access Token 발급, 유효하지 않으면 재로그인하도록
      */
     @PostMapping("/access_token")
@@ -70,16 +81,5 @@ public class UserController {
         String accessToken = jwtTokenUtils.validateRefreshToken(refreshToken);
 
         return new AccessTokenDto(accessToken);
-    }
-
-    /**
-     * [GET] /login/kakao
-     * 카카오 회원 로그인: JWT 토큰 발급
-     */
-    @GetMapping("/login/kakao")
-    public JwtTokenDto login(@RequestParam(name = "access_token") String accessToken,
-                             @RequestParam(name = "refresh_token") String refreshToken) {
-
-        return new JwtTokenDto(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/mypetlife/controller/UserController.java
+++ b/src/main/java/com/example/mypetlife/controller/UserController.java
@@ -4,8 +4,12 @@ import com.example.mypetlife.dto.user.LoginRequestDto;
 import com.example.mypetlife.dto.user.RegisterRequest;
 import com.example.mypetlife.dto.user.RegisterResponseDto;
 import com.example.mypetlife.entity.user.User;
+import com.example.mypetlife.jwt.AccessTokenDto;
 import com.example.mypetlife.jwt.JwtTokenDto;
+import com.example.mypetlife.jwt.JwtTokenUtils;
+import com.example.mypetlife.jwt.RefreshTokenDto;
 import com.example.mypetlife.service.UserService;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenUtils jwtTokenUtils;
 
     /**
      * [POST] /register
@@ -53,13 +58,28 @@ public class UserController {
     }
 
     /**
+     *
+     * Refresh Token 검증 후 유효하면 새로운 Access Token 발급, 유효하지 않으면 재로그인하도록
+     */
+    @PostMapping("/access_token")
+    public AccessTokenDto recreationAccessToke(@RequestBody RefreshTokenDto refreshTokenDto) {
+
+        String refreshToken = refreshTokenDto.getRefreshToken();
+
+        // Refresh Token 유효성 검증 후 유효하면 새로운 Access Token 발급
+        String accessToken = jwtTokenUtils.validateRefreshToken(refreshToken);
+
+        return new AccessTokenDto(accessToken);
+    }
+
+    /**
      * [GET] /login/kakao
      * 카카오 회원 로그인: JWT 토큰 발급
      */
     @GetMapping("/login/kakao")
-    public JwtTokenDto login(@RequestParam String token) {
+    public JwtTokenDto login(@RequestParam(name = "access_token") String accessToken,
+                             @RequestParam(name = "refresh_token") String refreshToken) {
 
-        JwtTokenDto tokenDto = new JwtTokenDto(token);
-        return tokenDto;
+        return new JwtTokenDto(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/mypetlife/exception/ErrorResponse.java
+++ b/src/main/java/com/example/mypetlife/exception/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.example.mypetlife.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,16 @@ public class ErrorResponse {
                 .body(ErrorResponse.builder()
                         .error(HttpStatus.BAD_REQUEST.name())
                         .message(e.getAllErrors().get(0).getDefaultMessage())
+                        .build());
+    }
+
+    public static ResponseEntity<ErrorResponse> createErrorResponse(ExpiredJwtException e) {
+
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.builder()
+                        .error(HttpStatus.UNAUTHORIZED.name())
+                        .message("Refresh Token이 만료되었습니다. 재로그인이 필요합니다.")
                         .build());
     }
 }

--- a/src/main/java/com/example/mypetlife/exception/ExceptionController.java
+++ b/src/main/java/com/example/mypetlife/exception/ExceptionController.java
@@ -1,5 +1,6 @@
 package com.example.mypetlife.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -24,5 +25,13 @@ public class ExceptionController {
 
         log.error("CustomException 발생: {}", e.getErrorCode().getMessage());
         return ErrorResponse.createErrorResponse(e.getErrorCode());
+    }
+
+    // ExpiredJwtException 예외 처리
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ErrorResponse> handleExpiredJwtException(ExpiredJwtException e) {
+
+        log.error("ExpiredJwtException 발생, 재로그인 필요");
+        return ErrorResponse.createErrorResponse(e);
     }
 }

--- a/src/main/java/com/example/mypetlife/jwt/AccessTokenDto.java
+++ b/src/main/java/com/example/mypetlife/jwt/AccessTokenDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class JwtTokenDto {
-    private String accessToken;
-    private String refreshToken;
+public class AccessTokenDto {
+
+    private final String accessToken;
 }

--- a/src/main/java/com/example/mypetlife/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/example/mypetlife/jwt/JwtExceptionFilter.java
@@ -1,6 +1,7 @@
 package com.example.mypetlife.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/example/mypetlife/jwt/JwtFilter.java
+++ b/src/main/java/com/example/mypetlife/jwt/JwtFilter.java
@@ -28,7 +28,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String token = jwtTokenUtils.getTokenFromHeader(request);
 
         // 있다면, 토큰이 유효한지 검증
-        if(jwtTokenUtils.validateToken(token)) {
+        if(jwtTokenUtils.validateAccessToken(token)) {
 
             // 토큰이 유효하면 authentication 반환 후 SecurityContextHolder에 저장
             Authentication authentication = jwtTokenUtils.getAuthentication(token);

--- a/src/main/java/com/example/mypetlife/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/example/mypetlife/jwt/JwtTokenUtils.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.stereotype.Component;
 import io.jsonwebtoken.security.Keys;
 
@@ -22,26 +21,94 @@ import java.util.Date;
 @Component
 public class JwtTokenUtils {
     private final Key signingKey;
-    private final JwtParser jwtParser; // jwt 해석시 사용되는 Parser
+    private final JwtParser jwtParser;
     private final JpaUserDetailManager manager;
 
-    public JwtTokenUtils(@Value("${jwt.secret}") String jwtSecret, JpaUserDetailManager manager) {
-        this.signingKey = Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    public JwtTokenUtils(@Value("${jwt.secret}") String secretKeyPlain, JpaUserDetailManager manager) {
+        this.signingKey = Keys.hmacShaKeyFor(secretKeyPlain.getBytes());
         jwtParser = Jwts.parserBuilder().setSigningKey(signingKey).build();
         this.manager = manager;
     }
 
-    // 사용자 정보를 바탕으로 JWT를 문자열로 생성
-    public String generateToken(CustomUserDetails customUserDetails){
-        Claims jwtClaims = Jwts.claims()
-                .setSubject(customUserDetails.getEmail()) // JWT에 email 정보 저장
-                .setIssuedAt(Date.from(Instant.now()))
-                .setExpiration(Date.from(Instant.now().plusSeconds(600)));
+    /*
+     * 최초 로그인시 JWT 토큰(Access, Refresh Token) 발급
+     */
+    public JwtTokenDto generateToken(CustomUserDetails customUserDetails){
 
-        return Jwts.builder()
-                .setClaims(jwtClaims)
-                .signWith(signingKey)
+        Claims claims = Jwts.claims()
+                .setSubject(customUserDetails.getEmail()); // JWT의 payload에 사용자 이메일 저장
+
+        // Access Token
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(Instant.now()))
+                .setExpiration(Date.from(Instant.now().plusSeconds(60 * 30)))
+                .signWith(SignatureAlgorithm.HS256, signingKey) // 사용할 암호화 알고리즘과 secret 값
+                .setHeaderParam("type","jwt")
                 .compact();
+
+        // Refresh Token
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(Instant.now()))
+                .setExpiration(Date.from(Instant.now().plusSeconds(60 * 60)))
+                .signWith(SignatureAlgorithm.HS256, signingKey)
+                .compact();
+
+        return new JwtTokenDto(accessToken, refreshToken);
+    }
+
+    /*
+     * Access Token 유효성 검사
+     */
+    public boolean validateAccessToken(String accessToken) {
+
+        // jjwt 라이브러리는 jwt 해석시 유효하지 않은 jwt이면 예외를 발생시킨다
+        try {
+            jwtParser.parseClaimsJws(accessToken); // jwt 해석
+            return true;
+        } catch (MalformedJwtException e) {
+            log.info("유효하지 않은 토큰");
+            throw new JwtException("유효하지 않은 토큰입니다");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 토큰");
+            throw new JwtException("만료된 토큰입니다. Refresh Token을 전달해 Access Token을 재발급하세요");
+        } catch (io.jsonwebtoken.JwtException e) {
+            log.info("잘못된 토큰");
+            throw new JwtException("잘못된 토큰입니다");
+        }
+    }
+
+    /*
+     * Refresh Token 유효성 검사
+     */
+    public String validateRefreshToken(String refreshToken) {
+
+        // jjwt 라이브러리는 jwt 해석시 유효하지 않은 jwt이면 예외를 발생시킨다
+        Jws<Claims> claims = jwtParser.parseClaimsJws(refreshToken);
+
+        // 검증 성공하면 새로운 AccessToken 발급
+        String accessToken = recreationAccessToken(claims.getBody().getSubject());
+        return accessToken;
+    }
+
+    /*
+     * Access Token 재발급
+     */
+    public String recreationAccessToken(String email) {
+
+        Claims claims = Jwts.claims()
+                .setSubject(email); // JWT의 payload에 사용자 이메일 저장
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + 60)) // 60초 (1분)
+                .signWith(SignatureAlgorithm.HS256, signingKey) // 사용할 암호화 알고리즘과 secret 값
+                .compact();
+
+        return accessToken;
     }
 
     /*
@@ -55,27 +122,6 @@ public class JwtTokenUtils {
         } else {
             log.info("요청 헤더에 토큰이 없음");
             throw new JwtException("요청 헤더에 토큰이 없습니다");
-        }
-    }
-
-    /*
-     * JWT 유효성 검사
-     */
-    public boolean validateToken(String token) {
-
-        // jjwt 라이브러리는 jwt 해석시 유효하지 않은 jwt이면 예외를 발생시킨다
-        try {
-            jwtParser.parseClaimsJws(token); // jwt 해석
-            return true;
-        } catch (MalformedJwtException e) {
-            log.info("유효하지 않은 토큰");
-            throw new JwtException("유효하지 않은 토큰입니다");
-        } catch (ExpiredJwtException e) {
-            log.info("만료된 토큰");
-            throw new JwtException("만료된 토큰입니다");
-        } catch (io.jsonwebtoken.JwtException e) {
-            log.info("잘못된 토큰");
-            throw new JwtException("잘못된 토큰입니다");
         }
     }
 

--- a/src/main/java/com/example/mypetlife/jwt/RefreshTokenDto.java
+++ b/src/main/java/com/example/mypetlife/jwt/RefreshTokenDto.java
@@ -1,0 +1,9 @@
+package com.example.mypetlife.jwt;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenDto {
+
+    private String refreshToken;
+}

--- a/src/main/java/com/example/mypetlife/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/mypetlife/oauth/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.example.mypetlife.oauth;
 
 import com.example.mypetlife.entity.CustomUserDetails;
+import com.example.mypetlife.jwt.JwtTokenDto;
 import com.example.mypetlife.jwt.JwtTokenUtils;
 import com.example.mypetlife.service.JpaUserDetailManager;
 import jakarta.servlet.ServletException;
@@ -42,10 +43,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         CustomUserDetails user = (CustomUserDetails) manager.loadUserByUsername(email);
 
         // 토큰 발급
-        String token = jwtTokenUtils.generateToken(user);
+        JwtTokenDto tokenDto = jwtTokenUtils.generateToken(user);
 
         // 파라미터로 토큰을 전달하면서 리다이렉트
-        String redirectUrl = String.format("http://localhost:8080/login/kakao?token=%s", token);
+        String redirectUrl = String.format("http://localhost:8080/login/kakao?access_token=%s&refresh_token=%s",
+                tokenDto.getAccessToken(), tokenDto.getRefreshToken());
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 }

--- a/src/main/java/com/example/mypetlife/service/UserService.java
+++ b/src/main/java/com/example/mypetlife/service/UserService.java
@@ -66,9 +66,9 @@ public class UserService {
         }
 
         // 토큰 발급
-        JwtTokenDto response = new JwtTokenDto(jwtTokenUtils.generateToken(user));
-        log.info(response.toString());
-        return response;
+        JwtTokenDto tokenDto = jwtTokenUtils.generateToken(user);
+        log.info(tokenDto.toString());
+        return tokenDto;
     }
 
     public User findById(Long id) {


### PR DESCRIPTION
- 로그인시 refresh token과 access token을 발급하도록 수정했습니다.
- refresh token의 만료 기간은 길게, access token의 만료 기간은 짧게 설정하여 access token이 만료되면 refresh token을 통해 access token을 재발급 받을 수 있습니다.
- 만약 refresh token 또한 만료되면 사용자는 재로그인해야 합니다.