### PR TITLE
[Feature] #36 챗봇관련 기능 구현

### DIFF
--- a/src/main/java/com/example/mypetlife/config/WebSocketConfig.java
+++ b/src/main/java/com/example/mypetlife/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.example.mypetlife.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        //  경로를 통해 들어오는 웹 소켓 통신 요청에 대한 처리를 위한 Handler 추가
+        registry.addHandler(webSocketHandler, "api/chat").setAllowedOrigins("*");
+
+    }
+}

--- a/src/main/java/com/example/mypetlife/controller/ChatController.java
+++ b/src/main/java/com/example/mypetlife/controller/ChatController.java
@@ -1,0 +1,46 @@
+package com.example.mypetlife.controller;
+
+import com.example.mypetlife.dto.chat.ChatMessageListDto;
+import com.example.mypetlife.entity.user.User;
+import com.example.mypetlife.jwt.JwtTokenUtils;
+import com.example.mypetlife.repository.ChatRoomRepository;
+import com.example.mypetlife.service.ChatService;
+import com.example.mypetlife.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+    private final ChatService chatService;
+    private final JwtTokenUtils jwtTokenUtils;
+    private final UserService userService;
+    private final ChatRoomRepository chatRoomRepository;
+
+    // 채팅 메세지 조회
+    @GetMapping("/getChatting/{roomId}")
+    public List<ChatMessageListDto> startChat(
+            HttpServletRequest request,
+            @PathVariable("roomId") Long roomId) {
+        // 유저 권한 확인
+        chatService.userCheck(request, roomId);
+        return chatService.readMessage(roomId);
+    }
+
+    // 채팅방 생성
+    @PostMapping("/createChat")
+    public String startChatbot(HttpServletRequest request) {
+        String email = jwtTokenUtils.getEmailFromHeader(request);
+        User user = userService.findByEmail(email);
+
+        return chatService.createRoom(user);
+    }
+
+
+}

--- a/src/main/java/com/example/mypetlife/dto/chat/ChatMessageDto.java
+++ b/src/main/java/com/example/mypetlife/dto/chat/ChatMessageDto.java
@@ -1,0 +1,13 @@
+package com.example.mypetlife.dto.chat;
+
+import lombok.Data;
+
+@Data
+public class ChatMessageDto {
+    public enum MessageType{
+        ENTER, TALK
+    }
+    private MessageType type;
+    private Long roomId;
+    private String message;
+}

--- a/src/main/java/com/example/mypetlife/dto/chat/ChatMessageListDto.java
+++ b/src/main/java/com/example/mypetlife/dto/chat/ChatMessageListDto.java
@@ -1,0 +1,29 @@
+package com.example.mypetlife.dto.chat;
+
+import com.example.mypetlife.entity.Message;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class ChatMessageListDto {
+    private Long roomId;
+    private Long id;
+    private String content;
+    private String receiver;
+    private LocalTime sendTime;
+
+    public static ChatMessageListDto createDto(Message message){
+        ChatMessageListDto dto = ChatMessageListDto.builder()
+                .id(message.getId())
+                .roomId(message.getChatRoom().getId())
+                .content(message.getContent())
+                .receiver(message.getReceiver().getUsername())
+                .sendTime(message.getSendTime())
+                .build();
+        return dto;
+    }
+
+}

--- a/src/main/java/com/example/mypetlife/entity/ChatRoom.java
+++ b/src/main/java/com/example/mypetlife/entity/ChatRoom.java
@@ -1,0 +1,35 @@
+package com.example.mypetlife.entity;
+
+import com.example.mypetlife.entity.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "chatroom")
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor
+public class ChatRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // receiver_id
+    @ManyToOne
+    @JsonIgnore
+    @JoinColumn(name = "receiver_id")
+    private User chatRoomUser;
+
+    @OneToMany(mappedBy = "chatRoom")
+    private List<Message> messages = new ArrayList<>();
+
+    public void addMessage(Message message){
+        this.messages.add(message);
+    }
+}

--- a/src/main/java/com/example/mypetlife/entity/Message.java
+++ b/src/main/java/com/example/mypetlife/entity/Message.java
@@ -1,29 +1,42 @@
 package com.example.mypetlife.entity;
 
 import com.example.mypetlife.entity.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
+@Getter
 @Table(name = "message")
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor
 public class Message {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String title;
     private String content;
 
     @Column(name = "send_date")
-    private LocalDateTime sendDate;
+    private LocalTime sendTime;
 
     // sender_id
     @ManyToOne
     @JoinColumn(name = "sender_id")
+    @JsonIgnore
     private User sender;
 
     // receiver_id
     @ManyToOne
     @JoinColumn(name = "receiver_id")
+    @JsonIgnore
     private User receiver;
+
+    @ManyToOne
+    @JsonIgnore
+    @JoinColumn(name="chatRoom_id")
+    private ChatRoom chatRoom;
 }

--- a/src/main/java/com/example/mypetlife/entity/user/User.java
+++ b/src/main/java/com/example/mypetlife/entity/user/User.java
@@ -1,6 +1,7 @@
 package com.example.mypetlife.entity.user;
 
 import com.example.mypetlife.entity.Calendar;
+import com.example.mypetlife.entity.ChatRoom;
 import com.example.mypetlife.entity.Message;
 import com.example.mypetlife.entity.Review;
 import com.example.mypetlife.entity.community.article.Article;
@@ -55,6 +56,9 @@ public class User {
 
     @OneToMany(mappedBy = "user")
     private List<LikeArticle> likeArticles = new ArrayList<>();
+
+    @OneToMany(mappedBy ="chatRoomUser")
+    private List<ChatRoom> chatRooms;
 
     //==생성 메서드==//
     public static User createUser(String username, String email, String password, String phone,

--- a/src/main/java/com/example/mypetlife/exception/ErrorCode.java
+++ b/src/main/java/com/example/mypetlife/exception/ErrorCode.java
@@ -25,8 +25,10 @@ public enum ErrorCode {
      */
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     NOT_FOUND_ARTICLE(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다"),
+    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
+    NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다"),
+    NOT_FOUND_TAG(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다"),
     NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
-
     /*
      * 409
      */

--- a/src/main/java/com/example/mypetlife/exception/ErrorCode.java
+++ b/src/main/java/com/example/mypetlife/exception/ErrorCode.java
@@ -18,19 +18,20 @@ public enum ErrorCode {
      * 401
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다"),
+    UNAUTHORIZED_CHATROOM(HttpStatus.UNAUTHORIZED, "해당 채팅방에 접근 권한이 없습니다."),
 
     /*
      * 404
      */
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     NOT_FOUND_ARTICLE(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다"),
-    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
-    NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다"),
-    NOT_FOUND_TAG(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다"),
+    NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "해당 채팅방을 찾을 수 없습니다."),
+
     /*
      * 409
      */
-    ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다")
+    ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다"),
+    ALREADY_EXIST_CHATROOM(HttpStatus.CONFLICT, "이미 채팅방을 생성하였습니다.")
 
     ;
 

--- a/src/main/java/com/example/mypetlife/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/example/mypetlife/jwt/JwtTokenUtils.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.web.socket.WebSocketSession;
 
 import java.security.Key;
 import java.time.Instant;
@@ -144,6 +145,20 @@ public class JwtTokenUtils {
 
         String token = getTokenFromHeader(request);
         String email = jwtParser.parseClaimsJws(token).getBody().getSubject();
+        return email;
+    }
+
+    // WebSocketSession -> 사용자 정보
+    public String getEmailFromSession(WebSocketSession session){
+        String token = session.getHandshakeHeaders().get("Authorization").get(0);
+        String jwt = "";
+        if(token != null && token.startsWith("Bearer ")) {
+            jwt= token.split(" ")[1];
+        } else {
+            log.info("요청 헤더에 토큰이 없음");
+            throw new JwtException("요청 헤더에 토큰이 없습니다");
+        }
+        String email = jwtParser.parseClaimsJws(jwt).getBody().getSubject();
         return email;
     }
 }

--- a/src/main/java/com/example/mypetlife/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/mypetlife/repository/ChatRoomRepository.java
@@ -1,0 +1,12 @@
+package com.example.mypetlife.repository;
+
+
+import com.example.mypetlife.entity.ChatRoom;
+import com.example.mypetlife.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findByChatRoomUser(User user);
+}

--- a/src/main/java/com/example/mypetlife/repository/MessageRepository.java
+++ b/src/main/java/com/example/mypetlife/repository/MessageRepository.java
@@ -1,0 +1,7 @@
+package com.example.mypetlife.repository;
+
+import com.example.mypetlife.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/com/example/mypetlife/service/ChatService.java
+++ b/src/main/java/com/example/mypetlife/service/ChatService.java
@@ -1,0 +1,144 @@
+package com.example.mypetlife.service;
+
+import com.example.mypetlife.dto.chat.ChatMessageDto;
+import com.example.mypetlife.dto.chat.ChatMessageListDto;
+import com.example.mypetlife.entity.ChatRoom;
+import com.example.mypetlife.entity.Message;
+import com.example.mypetlife.entity.user.User;
+import com.example.mypetlife.exception.CustomException;
+import com.example.mypetlife.exception.ErrorCode;
+import com.example.mypetlife.jwt.JwtTokenUtils;
+import com.example.mypetlife.repository.ChatRoomRepository;
+import com.example.mypetlife.repository.MessageRepository;
+import com.example.mypetlife.repository.UserRepository;
+import com.example.mypetlife.webSocket.MsgRoom;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.time.LocalTime;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+    private final ObjectMapper objectMapper;
+    private MsgRoom msgRoom;
+    private Map<Long, MsgRoom> msgRooms;
+    private Map<WebSocketSession, Long> sessionMap;
+    private final JwtTokenUtils jwtTokenUtils;
+    private final UserService userService;
+
+    @PostConstruct
+    private void init(){
+        msgRooms = new LinkedHashMap<>();
+        sessionMap = new LinkedHashMap<>();
+    }
+
+    public MsgRoom findRoomById(Long roomId){
+        return msgRooms.get(roomId);
+    }
+
+    public void addSession(WebSocketSession webSocketSession, Long roomId){
+        this.sessionMap.put(webSocketSession, roomId);
+    }
+
+    public void deleteSession(WebSocketSession webSocketSession){
+        Long key = this.sessionMap.get(webSocketSession);
+        MsgRoom msgRoom = this.msgRooms.get(key);
+
+        msgRoom.deleteSession(webSocketSession);
+        this.sessionMap.remove(webSocketSession);
+
+        return;
+    }
+
+    @Transactional
+    public String createRoom(User user){
+        Optional<ChatRoom> optionalRoom = chatRoomRepository.findByChatRoomUser(user);
+        if(optionalRoom.isEmpty()) {
+            ChatRoom newRoom = ChatRoom.builder()
+                    .chatRoomUser(user)
+                    .build();
+            chatRoomRepository.save(newRoom);
+
+            MsgRoom msgRoom = MsgRoom.builder()
+                    .id(newRoom.getId())
+                    .email(user.getEmail())
+                    .build();
+            msgRooms.put(msgRoom.getId(), msgRoom);
+            return "채팅방이 생성되었습니다. 채팅방 넘버 : "+newRoom.getId();
+        }else{
+            throw new CustomException(ErrorCode.ALREADY_EXIST_CHATROOM);
+        }
+
+    }
+
+    @Transactional
+    public void saveMessage(ChatMessageDto chatMessageDto, String email){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatMessageDto.getRoomId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHATROOM));
+
+        Message newMessage = Message.builder()
+                .content(chatMessageDto.getMessage())
+                .sendTime(LocalTime.now())
+                .chatRoom(chatRoom)
+                .receiver(user)
+                .build();
+
+        messageRepository.save(newMessage);
+
+    }
+
+    public <T> void sendMessage(WebSocketSession session, T message){
+        try{
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(message)));
+        }catch (IOException e){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    public List<ChatMessageListDto> readMessage(Long roomId){
+
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        chatRoom.getMessages();
+
+        List<ChatMessageListDto> chatMessageList = new ArrayList<>();
+
+        for (Message message:chatRoom.getMessages()) {
+            ChatMessageListDto dto = ChatMessageListDto.createDto(message);
+            chatMessageList.add(dto);
+        }
+        return chatMessageList;
+    }
+
+    // TODO 일반 유저일 경우 채팅방을 생성한 유저인지 확인, 관리자일 경우 통과
+    public void userCheck(HttpServletRequest request, Long roomId){
+        // 채팅방을 만든 사용자인지 확인
+        String email = jwtTokenUtils.getEmailFromHeader(request);
+        User user = userService.findByEmail(email);
+
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHATROOM));
+        if(user != chatRoom.getChatRoomUser()) throw new CustomException(ErrorCode.UNAUTHORIZED_CHATROOM);
+        // TODO 관리자일 경우는 접근 가능
+
+    }
+}

--- a/src/main/java/com/example/mypetlife/webSocket/MsgRoom.java
+++ b/src/main/java/com/example/mypetlife/webSocket/MsgRoom.java
@@ -1,0 +1,43 @@
+package com.example.mypetlife.webSocket;
+
+import com.example.mypetlife.dto.chat.ChatMessageDto;
+import com.example.mypetlife.service.ChatService;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@RequiredArgsConstructor
+public class MsgRoom {
+    private Long id;
+    private String email;
+    private static Set<WebSocketSession> sessions = new HashSet<>();
+
+    @Builder
+    public MsgRoom(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+    public void handleActions(WebSocketSession session, ChatMessageDto chatMessageDto, ChatService chatService, String email) {
+        // TODO 권한 확인
+        if (chatMessageDto.getType().equals(ChatMessageDto.MessageType.ENTER)) {
+            sessions.add(session);
+            chatMessageDto.setMessage(email + "님이 입장하셨습니다. 문의 내용을 보내주세요.");
+        }
+        chatService.saveMessage(chatMessageDto, email);
+        sendMessage(chatMessageDto, chatService);
+    }
+
+    public <T> void sendMessage(ChatMessageDto message, ChatService chatService) {
+        sessions.parallelStream().forEach(session -> chatService.sendMessage(session, message));
+    }
+
+    public static void deleteSession(WebSocketSession webSocketSession) {
+        sessions.remove(webSocketSession);
+    }
+}

--- a/src/main/java/com/example/mypetlife/webSocket/WebSocketHandler.java
+++ b/src/main/java/com/example/mypetlife/webSocket/WebSocketHandler.java
@@ -1,0 +1,66 @@
+package com.example.mypetlife.webSocket;
+
+import com.example.mypetlife.dto.chat.ChatMessageDto;
+import com.example.mypetlife.jwt.JwtTokenUtils;
+import com.example.mypetlife.service.ChatService;
+import com.example.mypetlife.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketHandler extends TextWebSocketHandler {
+    private final JwtTokenUtils jwtTokenUtils;
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
+    private final ChatService chatService;
+
+    // 연결되어있는 클라이언트 관리 리스트
+    private final List<WebSocketSession> sessions = new ArrayList<>();
+
+    @Override
+    // WebSocket 최초 연결
+    public void afterConnectionEstablished(WebSocketSession session){
+        String email = jwtTokenUtils.getEmailFromSession(session);
+
+        String name = userService.findByEmail(email).getUsername();
+
+        log.info("connected with session id:{}",session.getId());
+        log.info("name:{}",name);
+    }
+
+
+    @Override
+    // 메세지를 받으면
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        log.info("received: {}",payload);
+        ChatMessageDto chatMessageDto = objectMapper.readValue(payload, ChatMessageDto.class);
+        MsgRoom msgRoom = chatService.findRoomById(chatMessageDto.getRoomId());
+        // TODO 채팅방 생성한 유저인지 확인
+
+        if(chatMessageDto.getType().toString().equals("ENTER")){
+            chatService.addSession(session, msgRoom.getId());
+        }
+
+        String email = jwtTokenUtils.getEmailFromSession(session);
+        msgRoom.handleActions(session,chatMessageDto, chatService, email);
+    }
+
+
+    @Override
+    // 연결 종료
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status){
+        chatService.deleteSession(session);
+    }
+}


### PR DESCRIPTION
** fork

챗봇 관련 기능 구현
- 로그인한 사용자가 채팅방 생성
  - 이미 생성한 유저는 또 생성할 수 없다.
- 웹소켓 연결
- type: 'ENTER'로 메세지를 보내면 채팅 입장 메세지 send / 'TALK'으로 메세지를 보내면 메세지 저장
- roomId로 해당 채팅방의 메세지를 조회할 수 있음

** chat 테스트 완료
** 관리자 관련 기능 추가 예정